### PR TITLE
feat: create spec-gen response definition

### DIFF
--- a/src/main/java/io/gravitee/spec/gen/api/SpecGenRequest.java
+++ b/src/main/java/io/gravitee/spec/gen/api/SpecGenRequest.java
@@ -22,5 +22,6 @@ package io.gravitee.spec.gen.api;
 public record SpecGenRequest(
   String apiId,
   EndpointType endpointType,
-  Operation operation
+  Operation operation,
+  String userId
 ) {}

--- a/src/main/java/io/gravitee/spec/gen/api/SpecGenResponse.java
+++ b/src/main/java/io/gravitee/spec/gen/api/SpecGenResponse.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.spec.gen.api;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record SpecGenResponse(String apiId, String result) {}

--- a/src/main/java/io/gravitee/spec/gen/api/SpecGenResponse.java
+++ b/src/main/java/io/gravitee/spec/gen/api/SpecGenResponse.java
@@ -19,4 +19,4 @@ package io.gravitee.spec.gen.api;
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
-public record SpecGenResponse(String apiId, String result) {}
+public record SpecGenResponse(String apiId, String result, String userId) {}


### PR DESCRIPTION
Issue: https://gravitee.atlassian.net/browse/SAT-133

This PR brings SpecGenResponse definition interface
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.0-feat-SAT-133-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/spec/gen/api/gravitee-spec-gen-api/1.1.0-feat-SAT-133-SNAPSHOT/gravitee-spec-gen-api-1.1.0-feat-SAT-133-SNAPSHOT.zip)
  <!-- Version placeholder end -->
